### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,5 +1,6 @@
 class GoodsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
+  before_action :get_good, only: [:show, :edit, :update]
   before_action :current_user?, only: :edit
 
   def index
@@ -7,15 +8,12 @@ class GoodsController < ApplicationController
   end
 
   def show
-    @good = Good.find(params[:id])
   end
 
   def edit
-    @good = Good.find(params[:id])
   end
 
   def update
-    @good = Good.find(params[:id])
     if @good.update(good_params)
       redirect_to good_path
     else
@@ -37,10 +35,15 @@ class GoodsController < ApplicationController
   end
 
   private
+  
+  def get_good
+    @good = Good.find(params[:id])
+  end
+
 
   def current_user?
-    good = Good.find(params[:id])
-    if current_user.id == good.user_id
+    binding.pry 
+    if current_user.id == @good.user_id
     else
       redirect_to root_path
     end

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -42,7 +42,6 @@ class GoodsController < ApplicationController
 
 
   def current_user?
-    binding.pry 
     if current_user.id == @good.user_id
     else
       redirect_to root_path

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,5 +1,7 @@
 class GoodsController < ApplicationController
-  before_action :authenticate_user!, only: :new
+  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :current_user?, only: :edit
+
 
   def index
     @goods = Good.all.order('created_at DESC')
@@ -7,6 +9,19 @@ class GoodsController < ApplicationController
 
   def show
     @good = Good.find(params[:id])
+  end
+
+  def edit
+    @good = Good.find(params[:id])
+  end
+
+  def update
+    @good = Good.find(params[:id])
+    if @good.update(good_params)
+      redirect_to good_path
+    else
+      render :edit
+    end
   end
 
   def new
@@ -23,6 +38,14 @@ class GoodsController < ApplicationController
   end
 
   private
+
+  def current_user?
+    good = Good.find(params[:id])
+    if current_user.id == good.user_id
+    else
+      redirect_to root_path
+    end
+  end
 
   def good_params
     params.require(:good).permit(:image, :items_name, :items_explanation, :category_id, :status_id, :price, :payment_id, :prefecture_id,

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -2,7 +2,6 @@ class GoodsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :current_user?, only: :edit
 
-
   def index
     @goods = Good.all.order('created_at DESC')
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,5 +14,5 @@ class Category < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  has_many :items
+  has_many :goods
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -7,5 +7,5 @@ class Delivery < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  has_many :items
+  has_many :goods
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -6,5 +6,5 @@ class Payment < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  has_many :items
+  has_many :goods
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -19,5 +19,5 @@ class Prefecture < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  has_many :items
+  has_many :goods
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -10,5 +10,5 @@ class Status < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  has_many :items
+  has_many :goods
 end

--- a/app/views/goods/edit.html.erb
+++ b/app/views/goods/edit.html.erb
@@ -1,0 +1,161 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with(model: @good, local: true) do |f| %>
+
+    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
+    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+
+    <%# 商品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        商品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :image, id:"item-image" %>
+      </div>
+    </div>
+    <%# /商品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :items_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :items_explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:payment_id, Payment.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_id, Delivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', good_path(@good.id), class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/goods/edit.html.erb
+++ b/app/views/goods/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @good, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/goods/show.html.erb
+++ b/app/views/goods/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @good.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_good_path(@good.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% elsif  user_signed_in? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'goods#index'
-  resources :goods, only: [:index, :new, :create, :show]
+  resources :goods, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# what
商品情報の編集画面を作成

# why
出品者が自身の商品情報を編集することができるようにするため

# Gyazo
ログイン状態の出品者は、商品情報編集ページに遷移できる
https://gyazo.com/2e31509983a1dc20c5854f0181d848af
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/08e833d589ab002eae1b307d12a02ca5
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/76be659b7afa86c3ae3a1b680e5bfc22
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/68a40124438f5fbdd1dd2d6fb8a3517d
ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/19e5d99cf62ff0eed86ac186cc79004c
ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/d41214f3282314b8079473bdf0c9577b
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/2e31509983a1dc20c5854f0181d848af